### PR TITLE
docs: Fix a typo and add a link to AWS CLI installations instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This means: It makes sure that actions runs once **after** filters match. If fil
 * Run `yarn`
 * Run `node open-bot configurate` and answer questions
 * Run `yarn run deploy-prod` to deploy the bot (takes a while)
-  * Note you need to have AWS CLI tools installed and configurated
+  * Note you need to have AWS CLI tools installed and configured. See http://docs.aws.amazon.com/cli/latest/userguide/installing.html
 * Run `node open-bot` to gain access to the other tools, i. e. batch processing
 
 ## Contributing


### PR DESCRIPTION
- Fix a typo
- Add a link to AWS CLI installations instructions