### PR TITLE
add missing dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mkdirp": "^0.5.1",
     "promise-queue": "^2.2.3",
     "prompt": "^1.0.0",
+    "request": "^2.83.0",
     "serverless": "^1.9.0",
     "serverless-offline": "^3.13.1",
     "sync-exec": "^0.6.2"


### PR DESCRIPTION
_problem_
When running `node open-bot configurate` as is described in the README instructions, there's a dependency missing.

_initial error_
```
module.js:457
    throw err;
    ^

Error: Cannot find module 'request'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/plamen5kov/work/repos/openbot/lib/open-bot/travis.js:3:17)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)

```

_environment_
linux: fedora 24
node: 6.6.0
npm: 3.10.3

_solution_
Add the missing dependency: "request"